### PR TITLE
Improve performance 

### DIFF
--- a/src/Raffinert.Proj/DebugHelpers/ProjDebugView.cs
+++ b/src/Raffinert.Proj/DebugHelpers/ProjDebugView.cs
@@ -1,8 +1,18 @@
-﻿using System.Linq.Expressions;
+﻿using System.Diagnostics;
+using System.Linq.Expressions;
 
 namespace Raffinert.Proj.DebugHelpers;
 
 internal class ProjDebugView(IProj proj)
 {
-    public LambdaExpression Expression => proj.GetExpression();
+    public DebugViewInternal DebugView { get; } = new DebugViewInternal(proj);
+
+    internal class DebugViewInternal(IProj proj)
+    {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private readonly IProj _proj = proj;
+
+        public LambdaExpression Expression => _proj.GetExpression();
+        public LambdaExpression ExpandedExpression => _proj.GetExpandedExpression();
+    }
 }

--- a/src/Raffinert.Proj/Raffinert.Proj.csproj
+++ b/src/Raffinert.Proj/Raffinert.Proj.csproj
@@ -5,12 +5,12 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<Version>1.0.3</Version>
+	<Version>1.1.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<LangVersion>latest</LangVersion>
 	<AssemblyName>Raffinert.Proj</AssemblyName>
-	<AssemblyVersion>1.0.3</AssemblyVersion>
-	<FileVersion>1.0.3</FileVersion>
+	<AssemblyVersion>1.1.0</AssemblyVersion>
+	<FileVersion>1.1.0</FileVersion>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<Copyright>Copyright $([System.DateTime]::Now.Year) Yevhen Cherkes</Copyright>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/tests/Raffinert.Proj.IntegrationTests/ProjTests.cs
+++ b/tests/Raffinert.Proj.IntegrationTests/ProjTests.cs
@@ -132,7 +132,7 @@ public class ProjTests(ProductFilterFixture fixture) : IClassFixture<ProductFilt
         //var proj = Proj<Product, ProductDto?>.Create(p => p.Category.Products.Select(p1 => prodProj1.Map(p1)).FirstOrDefault());
         var proj = Proj<Product, ProductDto?>.Create(p => p.Category.Products.Select(prodProj1.Map).FirstOrDefault());
 
-        // This won't work
+        // This won't work for IQueryable
         //var proj = Proj<Product, ProductDto?>.Create(p => p.Category.Products.Select(Proj<Product, ProductDto>.Create(p1 => new ProductDto
         //{
         //    Id = p1.Id,


### PR DESCRIPTION
Improve performance by calling the MapCallVisitor at the root Proj only.
Cache GetExpandedExpression
Add both ExpandedExpression and Expression to DebugView