### PR TITLE
Added `MapIfNotNull` 

### DIFF
--- a/src/Raffinert.Proj/Raffinert.Proj.csproj
+++ b/src/Raffinert.Proj/Raffinert.Proj.csproj
@@ -5,12 +5,12 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<Version>1.1.0</Version>
+	<Version>1.1.1</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<LangVersion>latest</LangVersion>
 	<AssemblyName>Raffinert.Proj</AssemblyName>
-	<AssemblyVersion>1.1.0</AssemblyVersion>
-	<FileVersion>1.1.0</FileVersion>
+	<AssemblyVersion>1.1.1</AssemblyVersion>
+	<FileVersion>1.1.1</FileVersion>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	<Copyright>Copyright $([System.DateTime]::Now.Year) Yevhen Cherkes</Copyright>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/tests/Raffinert.Proj.IntegrationTests/ProjTests.cs
+++ b/tests/Raffinert.Proj.IntegrationTests/ProjTests.cs
@@ -1,7 +1,7 @@
-using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
 using Raffinert.Proj.IntegrationTests.Infrastructure;
 using Raffinert.Proj.IntegrationTests.Model;
+using System.Linq.Expressions;
 
 namespace Raffinert.Proj.IntegrationTests;
 
@@ -65,7 +65,7 @@ public class ProjTests(ProductFilterFixture fixture) : IClassFixture<ProductFilt
     }
 
     [Fact]
-    public async Task QueryableLinkTwoProjectionsByMap()
+    public async Task QueryableLinkTwoProjectionsByMapIfNotNull()
     {
         // Arrange
         var categoryProj = new CategoryProj();
@@ -74,7 +74,7 @@ public class ProjTests(ProductFilterFixture fixture) : IClassFixture<ProductFilt
             Id = p.Id,
             Name = p.Name,
             Price = p.Price,
-            Category = categoryProj.Map(p.Category)
+            Category = categoryProj.MapIfNotNull(p.Category)!
         });
 
         // Act


### PR DESCRIPTION
- Changed `Map` method in `Proj<TIn, TOut>` class to non-virtual.
- Added `MapIfNotNull` method to `Proj<TIn, TOut>` class.
- Updated `MapCallVisitor` to handle `MapIfNotNull` and added helper methods.
- Incremented project version in `Raffinert.Proj.csproj` from 1.1.0 to 1.1.1.
- Renamed and updated test method to use `MapIfNotNull` in `ProjTests.cs`.